### PR TITLE
ci: add standard triggers for Linux and Windows builds

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,6 +1,10 @@
 name: Linux-build
 
 on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,5 +1,9 @@
 name: Windows-build
 on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

- Add `push` to `main` and `pull_request` to `main` triggers for both Linux and Windows CI workflows
- Keep `workflow_dispatch` for manual triggering

This is the standard CI pattern:
- **push to main** - ensures main is always green after merge
- **PR to main** - validates changes before merge
- **workflow_dispatch** - allows manual re-runs

https://claude.ai/code/session_01KuJGEECyEpTuVpa8zH7dJo