### PR TITLE
ci: add automated release workflow on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,195 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    container:
+      image: nvidia/cuda:11.8.0-devel-ubuntu22.04
+    env:
+      _VCPKG_: ${{ github.workspace }}/vcpkg
+      VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg/bincache
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: Export GitHub Actions cache variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y git curl zip unzip tar build-essential pkg-config \
+            ninja-build autoconf automake libtool perl
+          git config --global --add safe.directory "*"
+
+      - name: Get CMake 3.29.0
+        run: |
+          curl -L https://github.com/Kitware/CMake/releases/download/v3.29.0/cmake-3.29.0-linux-x86_64.sh -o cmake-install.sh
+          chmod +x cmake-install.sh
+          ./cmake-install.sh --skip-license --prefix=/usr/local
+
+      - name: Create vcpkg binary cache directory
+        run: mkdir -p $VCPKG_DEFAULT_BINARY_CACHE
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Restore vcpkg
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env._VCPKG_ }}
+            !${{ env._VCPKG_ }}/buildtrees
+            !${{ env._VCPKG_ }}/packages
+            !${{ env._VCPKG_ }}/downloads
+            !${{ env._VCPKG_ }}/installed
+          key: ${{ runner.os }}-vcpkg-${{ hashFiles('**/vcpkg.json') }}
+          restore-keys: |
+            ${{ runner.os }}-vcpkg-
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.1
+        with:
+          vcpkgJsonGlob: 'vcpkg.json'
+
+      - name: Build
+        run: |
+          cmake -B build -S . --preset ninja-multi-vcpkg
+          cmake --build build --preset ninja-vcpkg-release
+
+      - name: Package Linux release
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          mkdir -p staging
+          cp -r build/bin/* staging/
+          cp README.md staging/ 2>/dev/null || true
+          tar -czf xenblocksMiner-${VERSION}-linux.tar.gz -C staging .
+
+      - name: Package HiveOS release
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          mkdir -p staging-hiveos
+          cp -r build/bin/* staging-hiveos/
+          cp -r hiveos/* staging-hiveos/
+          tar -czf xenblocksMiner-${VERSION}_hiveos.tar.gz -C staging-hiveos .
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-linux
+          path: '*.tar.gz'
+
+  build-windows:
+    runs-on: windows-2022
+    env:
+      VCPKG_DEFAULT_TRIPLET: x64-windows-static
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+    steps:
+      - name: Export GitHub Actions cache variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - uses: Jimver/cuda-toolkit@v0.2.30
+        id: cuda-toolkit
+        with:
+          cuda: '12.6.3'
+          use-github-cache: true
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: lukka/get-cmake@latest
+
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Set CUDA host compiler and trim PATH
+        shell: pwsh
+        run: |
+          $cl = (Get-Command cl.exe).Source
+          echo "CUDAHOSTCXX=$cl" >> $env:GITHUB_ENV
+          $keep = @()
+          foreach ($p in ($env:PATH -split ';')) {
+            if ($p -eq '') { continue }
+            if ($p -match '(?i)(CUDA|MSVC|Visual Studio|Windows Kits|cmake|ninja|vcpkg|\\git\\|System32|WindowsPowerShell|\\bin)') {
+              $keep += $p
+            }
+          }
+          $newPath = ($keep | Select-Object -Unique) -join ';'
+          Write-Host "Trimmed PATH from $($env:PATH.Length) to $($newPath.Length) chars"
+          echo "PATH=$newPath" >> $env:GITHUB_ENV
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgJsonGlob: 'vcpkg.json'
+
+      - name: CMake configure
+        shell: pwsh
+        run: |
+          cmake -S . -B build -G Ninja `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake" `
+            -DVCPKG_TARGET_TRIPLET=x64-windows-static `
+            -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded `
+            -DCMAKE_CUDA_COMPILER="$env:CUDA_PATH/bin/nvcc.exe" `
+            -DCUDAToolkit_ROOT="$env:CUDA_PATH"
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "=== CMakeError.log ==="
+            Get-ChildItem -Recurse -Filter "CMakeError.log" -ErrorAction SilentlyContinue | ForEach-Object {
+              Write-Host "--- $($_.FullName) ---"; Get-Content $_.FullName
+            }
+            exit 1
+          }
+
+      - name: CMake build
+        run: cmake --build build --config Release
+
+      - name: Package Windows release
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart("v")
+          New-Item -ItemType Directory -Path staging -Force
+          Copy-Item -Path build/bin/* -Destination staging/ -Recurse
+          if (Test-Path README.md) { Copy-Item README.md staging/ }
+          Compress-Archive -Path staging/* -DestinationPath "xenblocksMiner-${version}-windows.zip"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-windows
+          path: '*.zip'
+
+  publish:
+    needs: [build-linux, build-windows]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: List release files
+        run: ls -lh artifacts/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: artifacts/*


### PR DESCRIPTION
## Summary

- New workflow `.github/workflows/release.yml` triggered on `v*` tag push
- Builds Linux + Windows + HiveOS packages in parallel
- Automatically creates GitHub Release with all artifacts
- Uses `softprops/action-gh-release` with auto-generated release notes
- Artifact naming matches existing convention (e.g. `xenblocksMiner-1.4.0-linux.tar.gz`)

## Usage

```bash
git tag v1.5.0
git push origin v1.5.0
```

This will automatically build both platforms and create a Release at `https://github.com/woodysoil/XenblocksMiner/releases/tag/v1.5.0`

## Test plan

- [ ] Push a test tag (e.g. `v1.5.0-rc1`) to verify the workflow runs end-to-end

https://claude.ai/code/session_01KuJGEECyEpTuVpa8zH7dJo