### PR TITLE
ci: fix vcpkg caching and optimize CUDA install time

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -14,18 +14,10 @@ jobs:
       image: nvidia/cuda:11.8.0-devel-ubuntu22.04
     env:
       _VCPKG_: ${{ github.workspace }}/vcpkg
-      VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg/bincache
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
       VCPKG_DEFAULT_TRIPLET: x64-linux-static
       VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}/custom-triplets
       DEBIAN_FRONTEND: noninteractive
     steps:
-    - name: Export GitHub Actions cache environment variables
-      uses: actions/github-script@v7
-      with:
-        script: |
-          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
     - name: Install dependencies
       run: |
         apt-get update
@@ -39,16 +31,10 @@ jobs:
           chmod +x cmake-install.sh
           ./cmake-install.sh --skip-license --prefix=/usr/local
 
-    - name: "Create directory '${{ env.VCPKG_DEFAULT_BINARY_CACHE }}'"
-      run: mkdir -p $VCPKG_DEFAULT_BINARY_CACHE
-      shell: bash
-
     - uses: actions/checkout@v4
       with:
         submodules: recursive
 
-    # Restore vcpkg from the GitHub Action cache service. Note that packages are restored by vcpkg's binary caching
-    # when it is being run afterwards by CMake.
     - name: Restore vcpkg
       uses: actions/cache@v4
       with:
@@ -66,6 +52,12 @@ jobs:
       uses: lukka/run-vcpkg@v11.1
       with:
         vcpkgJsonGlob: 'vcpkg.json'
+
+    - name: Restore vcpkg installed packages
+      uses: actions/cache@v4
+      with:
+        path: build/vcpkg_installed
+        key: vcpkg-installed-${{ runner.os }}-x64-linux-static-${{ hashFiles('vcpkg.json') }}
 
     - name: Build
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,19 +14,10 @@ jobs:
       image: nvidia/cuda:11.8.0-devel-ubuntu22.04
     env:
       _VCPKG_: ${{ github.workspace }}/vcpkg
-      VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg/bincache
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
       VCPKG_DEFAULT_TRIPLET: x64-linux-static
       VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}/custom-triplets
       DEBIAN_FRONTEND: noninteractive
     steps:
-      - name: Export GitHub Actions cache variables
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
       - name: Install dependencies
         run: |
           apt-get update
@@ -39,9 +30,6 @@ jobs:
           curl -L https://github.com/Kitware/CMake/releases/download/v3.29.0/cmake-3.29.0-linux-x86_64.sh -o cmake-install.sh
           chmod +x cmake-install.sh
           ./cmake-install.sh --skip-license --prefix=/usr/local
-
-      - name: Create vcpkg binary cache directory
-        run: mkdir -p $VCPKG_DEFAULT_BINARY_CACHE
 
       - uses: actions/checkout@v4
         with:
@@ -64,6 +52,12 @@ jobs:
         uses: lukka/run-vcpkg@v11.1
         with:
           vcpkgJsonGlob: 'vcpkg.json'
+
+      - name: Restore vcpkg installed packages
+        uses: actions/cache@v4
+        with:
+          path: build/vcpkg_installed
+          key: vcpkg-installed-${{ runner.os }}-x64-linux-static-${{ hashFiles('vcpkg.json') }}
 
       - name: Build
         run: |
@@ -95,19 +89,13 @@ jobs:
     runs-on: windows-2022
     env:
       VCPKG_DEFAULT_TRIPLET: x64-windows-static
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
     steps:
-      - name: Export GitHub Actions cache variables
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
       - uses: Jimver/cuda-toolkit@v0.2.30
         id: cuda-toolkit
         with:
           cuda: '12.6.3'
+          method: network
+          sub-packages: '["nvcc", "cudart", "nvml_dev", "visual_studio_integration"]'
           use-github-cache: true
 
       - uses: actions/checkout@v4
@@ -140,6 +128,12 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgJsonGlob: 'vcpkg.json'
+
+      - name: Restore vcpkg installed packages
+        uses: actions/cache@v4
+        with:
+          path: build/vcpkg_installed
+          key: vcpkg-installed-${{ runner.os }}-x64-windows-static-${{ hashFiles('vcpkg.json') }}
 
       - name: CMake configure
         shell: pwsh

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -11,19 +11,13 @@ jobs:
     runs-on: windows-2022
     env:
       VCPKG_DEFAULT_TRIPLET: x64-windows-static
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
     steps:
-      - name: Export GitHub Actions cache variables
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
       - uses: Jimver/cuda-toolkit@v0.2.30
         id: cuda-toolkit
         with:
           cuda: '12.6.3'
+          method: network
+          sub-packages: '["nvcc", "cudart", "nvml_dev", "visual_studio_integration"]'
           use-github-cache: true
 
       - uses: actions/checkout@v4
@@ -41,7 +35,6 @@ jobs:
         run: |
           $cl = (Get-Command cl.exe).Source
           echo "CUDAHOSTCXX=$cl" >> $env:GITHUB_ENV
-          # Trim PATH to under 8191 chars to avoid "input line too long" from nvcc's vcvarsall.
           $keep = @()
           foreach ($p in ($env:PATH -split ';')) {
             if ($p -eq '') { continue }
@@ -57,6 +50,12 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgJsonGlob: 'vcpkg.json'
+
+      - name: Restore vcpkg installed packages
+        uses: actions/cache@v4
+        with:
+          path: build/vcpkg_installed
+          key: vcpkg-installed-${{ runner.os }}-x64-windows-static-${{ hashFiles('vcpkg.json') }}
 
       - name: CMake configure
         shell: pwsh


### PR DESCRIPTION
## Summary

Two major CI optimizations:

### 1. Fix broken vcpkg binary caching
- The `x-gha` vcpkg binary cache backend has been **removed** in newer vcpkg versions
- `warning: The 'x-gha' binary caching backend has been removed.`
- All 51 vcpkg packages were being rebuilt from source every run (~10 min)
- **Fix**: Use `actions/cache` to cache `build/vcpkg_installed` directory
- With warm cache: ~10min → ~10s

### 2. Optimize CUDA toolkit install (Windows)
- Full CUDA toolkit install takes ~12 minutes (silent installer)
- **Fix**: Use `method: network` with `sub-packages: ["nvcc", "cudart", "nvml_dev", "visual_studio_integration"]`
- Only downloads what's needed instead of full 4GB+ toolkit
- Expected: ~12min → ~2-3min

### Expected total improvement (Windows)
| Step | Before | After (warm cache) |
|------|--------|-------------------|
| CUDA toolkit | ~12min | ~2-3min |
| vcpkg/CMake configure | ~10min | ~30s |
| CMake build | ~29s | ~29s |
| **Total** | **~24min** | **~4-5min** |

https://claude.ai/code/session_01KuJGEECyEpTuVpa8zH7dJo